### PR TITLE
Set up complex vignette as articles

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,4 +7,4 @@ LICENSE.md
 readme.md
 readme.html
 .gitignore
-
+^articles

--- a/articles/TADAAssessmentUnitUseCase.Rmd
+++ b/articles/TADAAssessmentUnitUseCase.Rmd
@@ -5,7 +5,7 @@ editor: visual
 author: "TADA Team"
 date: "`r Sys.Date()`"
 output: 
-  rmarkdown::html_vignette:
+  rmarkdown::html_document:
     toc: true
     fig_caption: yes
     fig_height: 8

--- a/articles/TADAWaterSciConWorkshopDemo.Rmd
+++ b/articles/TADAWaterSciConWorkshopDemo.Rmd
@@ -5,7 +5,7 @@ editor: visual
 author: "TADA Team"
 date: "`r Sys.Date()`"
 output: 
-  rmarkdown::html_vignette:
+  rmarkdown::html_document:
     toc: true
     fig_caption: yes
     fig_height: 8


### PR DESCRIPTION
Change water sci con and assessment unit use case vignettes to articles to prevent intermittent check issues.