### PR TITLE
509 the foramt of the reference table from epatadas tada getsynonymref function

### DIFF
--- a/R/TADARefTables.R
+++ b/R/TADARefTables.R
@@ -18,22 +18,18 @@ TADA_GetNutrientSummationRef <- function() {
 
 #' Generate Unique Synonym Reference Table
 #'
-#' Function generates a synonym reference table containing all unique
-#' combinations of TADA.CharacteristicName, TADA.ResultSampleFractionText,
-#' TADA.MethodSpeciationName, and TADA.ResultMeasure.MeasureUnitCode. The
-#' function also joins in some TADA-specific suggested synonyms for nutrients
-#' and priority parameters. These target synonyms (denoted in the reference
-#' table with the prefix "Target.") are intended to help the user aggregate
-#' synonymous data that may be uploaded with slightly different metadata
-#' conventions and prepare nutrient data for total N and P summations. Users can
-#' review how their input data relates to target synonyms for
-#' TADA.CharacteristicName, TADA.ResultSampleFractionText,
-#' TADA.MethodSpeciationName, and TADA.ResultMeasure.MeasureUnitCode. Once
-#' the synonym table is created, users may optionally edit the target columns in
-#' the reference table to meet their needs. Additionally, the function assumes
-#' the user has already removed any data containing invalid
-#' characteristic-unit-fraction-speciation combinations (i.e. user has already
-#' run TADA_FlagFraction, TADA_FlagSpeciation, TADA_FlagResultUnit, etc.).
+#' Function generates a synonym reference table containing all unique combinations of 
+#' TADA.CharacteristicName, TADA.ResultSampleFractionText, and TADA.MethodSpeciationName. The 
+#' function also joins in some TADA-specific suggested synonyms for nutrients and priority parameters. 
+#' These target synonyms (denoted in the reference table with the prefix "Target.") are intended to 
+#' help the user aggregate synonymous data that may be uploaded with slightly different metadata
+#' conventions and prepare nutrient data for total N and P summations. Users can review how their 
+#' input data relates to target synonyms forTADA.CharacteristicName, TADA.ResultSampleFractionText,
+#' and TADA.MethodSpeciationName. Once the synonym table is created, users may optionally edit the 
+#' target columns in the reference table to meet their needs. Additionally, the function assumes
+#' the user has already removed any data containing invalid characteristic-unit-fraction-speciation 
+#' combinations (i.e. user has alreadyrun TADA_FlagFraction, TADA_FlagSpeciation, TADA_FlagResultUnit, 
+#' etc.).
 #'
 #' @param .data TADA dataframe. If a data frame is not provided, the function will return the default internal reference table.
 #'

--- a/R/Transformations.R
+++ b/R/Transformations.R
@@ -8,10 +8,9 @@
 #' suggested synonym naming for some priority characteristics. Where a suggested
 #' characteristic name, fraction, speciation, or unit is present, the function
 #' will convert the TADA.CharacteristicName, TADA.ResultSampleFractionText,
-#' TADA.MethodSpeciationName, and/or TADA.ResultMeasure.MeasureUnitCode to
-#' the target format. In cases where a target unit or speciation differs from
-#' the existing unit or speciation, the reference table will also apply
-#' multiplication conversion factors to the TADA.ResultMeasureValue.
+#' and TADA.MethodSpeciationName to the target format. In cases where a target 
+#' speciation differs from the existing speciation, the reference table will 
+#' also apply multiplication conversion factors to the TADA.ResultMeasureValue.
 #'
 #' @param .data TADA dataframe
 #' @param ref Optional argument to specify which dataframe to use as a reference

--- a/man/TADA_GetSynonymRef.Rd
+++ b/man/TADA_GetSynonymRef.Rd
@@ -13,22 +13,18 @@ TADA_GetSynonymRef(.data)
 Synonym Reference Table unique to the input dataframe
 }
 \description{
-Function generates a synonym reference table containing all unique
-combinations of TADA.CharacteristicName, TADA.ResultSampleFractionText,
-TADA.MethodSpeciationName, and TADA.ResultMeasure.MeasureUnitCode. The
-function also joins in some TADA-specific suggested synonyms for nutrients
-and priority parameters. These target synonyms (denoted in the reference
-table with the prefix "Target.") are intended to help the user aggregate
-synonymous data that may be uploaded with slightly different metadata
-conventions and prepare nutrient data for total N and P summations. Users can
-review how their input data relates to target synonyms for
-TADA.CharacteristicName, TADA.ResultSampleFractionText,
-TADA.MethodSpeciationName, and TADA.ResultMeasure.MeasureUnitCode. Once
-the synonym table is created, users may optionally edit the target columns in
-the reference table to meet their needs. Additionally, the function assumes
-the user has already removed any data containing invalid
-characteristic-unit-fraction-speciation combinations (i.e. user has already
-run TADA_FlagFraction, TADA_FlagSpeciation, TADA_FlagResultUnit, etc.).
+Function generates a synonym reference table containing all unique combinations of
+TADA.CharacteristicName, TADA.ResultSampleFractionText, and TADA.MethodSpeciationName. The
+function also joins in some TADA-specific suggested synonyms for nutrients and priority parameters.
+These target synonyms (denoted in the reference table with the prefix "Target.") are intended to
+help the user aggregate synonymous data that may be uploaded with slightly different metadata
+conventions and prepare nutrient data for total N and P summations. Users can review how their
+input data relates to target synonyms forTADA.CharacteristicName, TADA.ResultSampleFractionText,
+and TADA.MethodSpeciationName. Once the synonym table is created, users may optionally edit the
+target columns in the reference table to meet their needs. Additionally, the function assumes
+the user has already removed any data containing invalid characteristic-unit-fraction-speciation
+combinations (i.e. user has alreadyrun TADA_FlagFraction, TADA_FlagSpeciation, TADA_FlagResultUnit,
+etc.).
 }
 \examples{
 # Load example dataset:

--- a/man/TADA_HarmonizeSynonyms.Rd
+++ b/man/TADA_HarmonizeSynonyms.Rd
@@ -39,10 +39,9 @@ user (recommended), or the default TADA-provided synonym table, containing
 suggested synonym naming for some priority characteristics. Where a suggested
 characteristic name, fraction, speciation, or unit is present, the function
 will convert the TADA.CharacteristicName, TADA.ResultSampleFractionText,
-TADA.MethodSpeciationName, and/or TADA.ResultMeasure.MeasureUnitCode to
-the target format. In cases where a target unit or speciation differs from
-the existing unit or speciation, the reference table will also apply
-multiplication conversion factors to the TADA.ResultMeasureValue.
+and TADA.MethodSpeciationName to the target format. In cases where a target
+speciation differs from the existing speciation, the reference table will
+also apply multiplication conversion factors to the TADA.ResultMeasureValue.
 }
 \examples{
 # Load example dataset:


### PR DESCRIPTION
updated documentation for TADA_GetSynonymRef and TADA_HarmonizeSynonyms to remove any references to unit conversion as target units are no longer included in harmonization, but occur elsewhere in the workflow (TADA_ConvertResultUnits)