### PR TITLE
534 dataset growing mt example

### DIFF
--- a/R/UnitConversions.R
+++ b/R/UnitConversions.R
@@ -593,13 +593,14 @@ TADA_ConvertResultUnits <- function(.data, ref = "tada", transform = TRUE) {
     # create detection unit ref
     det.ref <- unit.ref %>%
       dplyr::ungroup() %>%
-      dplyr::rename(DetectionQuantitationLimitMeasure.MeasureUnitCode = ResultMeasure.MeasureUnitCode) %>%
-      dplyr::select(-TADA.ResultMeasure.MeasureUnitCode) %>%
+      dplyr::rename(DetectionQuantitationLimitMeasure.MeasureUnitCode = ResultMeasure.MeasureUnitCode,
+                    TADA.DetectionQuantitationLimitMeasure.MeasureUnitCode = TADA.ResultMeasure.MeasureUnitCode) %>%
       dplyr::distinct()
 
     det.join <- c(
       "TADA.CharacteristicName",
-      "DetectionQuantitationLimitMeasure.MeasureUnitCode"
+      "DetectionQuantitationLimitMeasure.MeasureUnitCode",
+      "TADA.DetectionQuantitationLimitMeasure.MeasureUnitCode"
     )
 
     # Transform TADA.DetectionQuantitationLimitMeasure.MeasureValue value to target value only if target unit exists

--- a/R/UnitConversions.R
+++ b/R/UnitConversions.R
@@ -609,10 +609,10 @@ TADA_ConvertResultUnits <- function(.data, ref = "tada", transform = TRUE) {
       dplyr::left_join(det.ref, by = det.join) %>%
       # apply conversions where there is a target unit, use original value if no target unit
       dplyr::mutate(TADA.DetectionQuantitationLimitMeasure.MeasureValue = dplyr::case_when(
-        !is.na(TADA.Target.ResultMeasure.MeasureUnitCode) ~ ((TADA.DetectionQuantitationLimitMeasure.MeasureValue - TADA.WQXUnitConversionCoefficient) * TADA.WQXUnitConversionFactor),
+        is.na(TADA.DetectionQuantitationLimitMeasure.MeasureValue) ~ TADA.DetectionQuantitationLimitMeasure.MeasureValue,
+        !is.na(TADA.Target.ResultMeasure.MeasureUnitCode) ~ ((TADA.DetectionQuantitationLimitMeasure.MeasureValue + TADA.WQXUnitConversionCoefficient) * TADA.WQXUnitConversionFactor),
         is.na(TADA.Target.ResultMeasure.MeasureUnitCode) ~ TADA.DetectionQuantitationLimitMeasure.MeasureValue
       ))
-
     rm(clean.data)
 
     # populate TADA.DetectionQuantitationLimitMeasure.MeasureUnitCode


### PR DESCRIPTION
Update to TADA_ConvertResultUnits to prevent the dataset from growing when converting result units or using autoclean. 

The problem as many-to-many relationships between detection limit units and the conversion reference. Adding "TADA.DetectionQuantitationLimitMeasure.MeasureUnitCode" as another joining column prevents many-to-manys at this join.