### PR TITLE
Update continuous data flagging

### DIFF
--- a/R/ResultFlagsIndependent.R
+++ b/R/ResultFlagsIndependent.R
@@ -260,13 +260,20 @@ TADA_FlagContinuousData <- function(.data, clean = FALSE, flaggedonly = FALSE, t
 
   # everything not YET in cont dataframe
   noncont.data <- subset(.data, !.data$ResultIdentifier %in% cont.data$ResultIdentifier)
+  
+  # import WQX Activity Type Ref
+  qc.ref <- utils::read.csv(system.file("extdata", "WQXActivityTypeRef.csv", package = "EPATADA")) %>%
+    dplyr::select(Code, TADA.ActivityType.Flag) %>%
+    dplyr::rename(ActivityTypeCode = Code) %>%
+    dplyr::distinct()
 
   # if time field is not NA, find time difference between results
-
   if (length(noncont.data) >= 1) {
     info_match <- noncont.data %>%
+      # Add TADA.ActivityType.Flag
+      dplyr::left_join(qc.ref, by = "ActivityTypeCode") %>%
       # remove quality control samples
-      dplyr::filter(!grepl("Quality Control", ActivityTypeCode)) %>%
+      dplyr::filter(TADA.ActivityType.Flag == "Non_QC") %>%
       dplyr::group_by(
         TADA.LatitudeMeasure, TADA.LongitudeMeasure,
         OrganizationIdentifier, TADA.ComparableDataIdentifier,
@@ -293,7 +300,7 @@ TADA_FlagContinuousData <- function(.data, clean = FALSE, flaggedonly = FALSE, t
       dplyr::filter(time_diff_lead <= time_difference |
         time_diff_lag <= time_difference)
 
-    rm(info_match)
+    rm(info_match, qc.ref)
 
     # if matches are identified change flag to continuous
     noncont.data <- noncont.data %>%

--- a/R/ResultFlagsIndependent.R
+++ b/R/ResultFlagsIndependent.R
@@ -265,6 +265,8 @@ TADA_FlagContinuousData <- function(.data, clean = FALSE, flaggedonly = FALSE, t
 
   if (length(noncont.data) >= 1) {
     info_match <- noncont.data %>%
+      # remove quality control samples
+      dplyr::filter(!grepl("Quality Control", ActivityTypeCode)) %>%
       dplyr::group_by(
         TADA.LatitudeMeasure, TADA.LongitudeMeasure,
         OrganizationIdentifier, TADA.ComparableDataIdentifier,


### PR DESCRIPTION
Added filter to exclude quality control samples from continuous data search. I have not been able to recreate the issue with all NAs in continuous flag column by using examples from previous test failures or random data sets.